### PR TITLE
Adding Configuration for the Media Folder being hosted on AWS S3 bucket

### DIFF
--- a/backend/config/middlewares.js
+++ b/backend/config/middlewares.js
@@ -1,4 +1,4 @@
-module.exports = ({env}) => ([
+module.exports = ({ env }) => ([
   'strapi::errors',
   {
     name: 'strapi::security',
@@ -12,19 +12,19 @@ module.exports = ({env}) => ([
             'data:',
             'blob:',
             'dl.airtable.com',
-            env('AWS_MEDIA_BUCKET') + '.s3.' + env('AWS_REGION') + '.amazonaws.com',
+            env('AWS_MEDIA_BUCKET') + '.s3.' + env('AWS_REGION') + '.amazonaws.com'
           ],
           'media-src': [
             "'self'",
             'data:',
             'blob:',
             'dl.airtable.com',
-            env('AWS_MEDIA_BUCKET') + '.s3.' + env('AWS_REGION') + '.amazonaws.com',
+            env('AWS_MEDIA_BUCKET') + '.s3.' + env('AWS_REGION') + '.amazonaws.com'
           ],
-          upgradeInsecureRequests: null,
-        },
-      },
-    },
+          upgradeInsecureRequests: null
+        }
+      }
+    }
   },
   'strapi::cors',
   'strapi::poweredBy',

--- a/backend/config/middlewares.js
+++ b/backend/config/middlewares.js
@@ -1,6 +1,31 @@
-module.exports = [
+module.exports = ({env}) => ([
   'strapi::errors',
-  'strapi::security',
+  {
+    name: 'strapi::security',
+    config: {
+      contentSecurityPolicy: {
+        useDefaults: true,
+        directives: {
+          'connect-src': ["'self'", 'https:'],
+          'img-src': [
+            "'self'",
+            'data:',
+            'blob:',
+            'dl.airtable.com',
+            env('AWS_MEDIA_BUCKET') + '.s3.' + env('AWS_REGION') + '.amazonaws.com',
+          ],
+          'media-src': [
+            "'self'",
+            'data:',
+            'blob:',
+            'dl.airtable.com',
+            env('AWS_MEDIA_BUCKET') + '.s3.' + env('AWS_REGION') + '.amazonaws.com',
+          ],
+          upgradeInsecureRequests: null,
+        },
+      },
+    },
+  },
   'strapi::cors',
   'strapi::poweredBy',
   'strapi::logger',
@@ -9,4 +34,4 @@ module.exports = [
   'strapi::session',
   'strapi::favicon',
   'strapi::public'
-]
+])

--- a/backend/config/plugins.js
+++ b/backend/config/plugins.js
@@ -7,14 +7,14 @@ module.exports = ({ env }) => ({
         secretAccessKey: env('AWS_ACCESS_SECRET'),
         region: env('AWS_REGION'),
         params: {
-          Bucket: env('AWS_MEDIA_BUCKET'),
-        },
+          Bucket: env('AWS_MEDIA_BUCKET')
+        }
       },
       actionOptions: {
         upload: {},
         uploadStream: {},
-        delete: {},
-      },
-    },
-  },
+        delete: {}
+      }
+    }
+  }
 })

--- a/backend/config/plugins.js
+++ b/backend/config/plugins.js
@@ -1,0 +1,20 @@
+module.exports = ({ env }) => ({
+  upload: {
+    config: {
+      provider: 'aws-s3',
+      providerOptions: {
+        accessKeyId: env('AWS_ACCESS_KEY_ID'),
+        secretAccessKey: env('AWS_ACCESS_SECRET'),
+        region: env('AWS_REGION'),
+        params: {
+          Bucket: env('AWS_MEDIA_BUCKET'),
+        },
+      },
+      actionOptions: {
+        upload: {},
+        uploadStream: {},
+        delete: {},
+      },
+    },
+  },
+})

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2580,6 +2580,15 @@
         "sendmail": "^1.6.1"
       }
     },
+    "@strapi/provider-upload-aws-s3": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@strapi/provider-upload-aws-s3/-/provider-upload-aws-s3-4.5.1.tgz",
+      "integrity": "sha512-nZESfx2/zuu2TrhJ68DF8Z/Bq4e/rAAOiVQOvhH7u3PvJ+8oiQExePMeT5FYVYigZR30AoJLvdIBRULdksp6VA==",
+      "requires": {
+        "aws-sdk": "2.1215.0",
+        "lodash": "4.17.21"
+      }
+    },
     "@strapi/provider-upload-local": {
       "version": "4.4.7",
       "resolved": "https://registry.npmjs.org/@strapi/provider-upload-local/-/provider-upload-local-4.4.7.tgz",
@@ -3600,6 +3609,69 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
+    },
+    "aws-sdk": {
+      "version": "2.1215.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1215.0.tgz",
+      "integrity": "sha512-btOexIY0O2F+HhjytToaYuub2HEdLqccZSM8rbT3nrbXo7U4k4Gqi6SbMGi2a+vEpj8lY8dAuMR2lvvVs4Ib9Q==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
+        },
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
+        }
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -8281,6 +8353,11 @@
         }
       }
     },
+    "jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
+    },
     "joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -11714,6 +11791,11 @@
         }
       }
     },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
+    },
     "scheduler": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
@@ -13683,6 +13765,20 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@strapi/plugin-i18n": "4.4.7",
     "@strapi/plugin-users-permissions": "4.4.7",
+    "@strapi/provider-upload-aws-s3": "^4.5.1",
     "@strapi/strapi": "4.4.7",
     "better-sqlite3": "7.4.6",
     "mysql": "^2.18.1",


### PR DESCRIPTION
One problem that we previously had is that each person could upload media files to their individual /backend/public/upload folder, but those would not be shared with everyone.  To resolve this issue, we have configured Strapi to use a single media repository on S3.  Any new uploaded files will be uploaded to S3 and will be served from there.
See Zach for .ENV changes.