### PR TITLE
changes for exporting

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -37,3 +37,6 @@ yarn-error.log*
 next-env.d.ts
 
 /data/*.json
+
+#Zach's copy script
+copy_to_windows.sh

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  trailingSlash: true,
   reactStrictMode: true
 }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "next build",
     "export": "next build && next export",
+    "export-zach": "next build && next export -o '/mnt/f/Google Drive/school/S10/soundbendor/'",
     "prestart": "node prestart",
     "start": "next dev",
     "lint": "next lint"


### PR DESCRIPTION
This is a minor change so that the exports work on S3.
The change to frontend/package.json exists so that I can easily export the content to a folder that is not hidden in my ubuntu WSL.  If this were a perfect implementation, I would add a record in the .env file, and use command line grep commands to get the content of the path, but that would take a while for me to figure out and nobody, except zach, would run `npm run-script export-zach` to export the content.