### PR TITLE
Changes to routing making the least amount of changes

### DIFF
--- a/frontend/models/people.js
+++ b/frontend/models/people.js
@@ -25,7 +25,6 @@ const peopleFilterFunctions = {
 
   filterClass: (key, value, obj) => {
     const lValue = value.toLowerCase()
-    console.log(lValue)
     const className = PersonClassService.getPersonClass({ id__eq: obj.person_class }).Name.toLowerCase()
     return (className.includes(lValue))
   }

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,8 +1,18 @@
 /** @type {import('next').NextConfig} */
 import BaseService from './models/__base.js'
 
-const buildPathMapQuery = (urlPath) => {
-  return { __nextDefaultLocale: 'en-US', __nextLocale: 'en-US', path: urlPath }
+async function getRewrites () {
+  const PageService = BaseService.constructDefaultService('api::page.page', 'page')
+  const pages = PageService.getPages()
+  const rewrites = []
+  let pageType = ''
+  for (const page of pages) {
+    pageType = page.PageType.toLowerCase()
+    if (pageType === 'content') {
+      rewrites.push({ source: page.URLPath, destination: '/content?path=' + page.URLPath })
+    }
+  }
+  return rewrites
 }
 
 const nextConfig = {
@@ -10,20 +20,9 @@ const nextConfig = {
     locales: ['en-US'],
     defaultLocale: 'en-US'
   },
+  rewrites: getRewrites,
   trailingSlash: true,
-  reactStrictMode: true,
-  exportPathMap: async function (defaultPathMap, { dev, dir, outDir, distDir, buildId }) {
-    const PageService = BaseService.constructDefaultService('api::page.page', 'page')
-    const pages = PageService.getPages()
-    const pathMap = {}
-    let suffix = ''
-    if (dev) suffix = '/'
-    for (const page of pages) {
-      const pageType = page.PageType.toLowerCase()
-      pathMap[page.URLPath] = { page: suffix + pageType, query: buildPathMapQuery(page.URLPath) }
-    }
-    return pathMap
-  }
+  reactStrictMode: true
 }
 
 export default nextConfig

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "export-zach": "next build && next export -o '/mnt/f/Google Drive/school/S10/soundbendor/'",
     "prestart": "node prestart",
     "start": "next dev",
+    "prod": "next start",
     "lint": "next lint"
   },
   "dependencies": {

--- a/frontend/pages/projects.js
+++ b/frontend/pages/projects.js
@@ -21,7 +21,6 @@ const createProjectYearListDisplay = (projectYears) => {
 
 const Projects = () => {
   const projects = ProjectService.getProjects()
-  console.log(projects)
   const projectSearchPlaceholder = '(e.g., ' + projects[0].Name + ')'
   const [projectListDisplay, setProjectListDisplay] = useState(createProjectListDisplay(projects))
   const projectYearListDisplay = createProjectYearListDisplay(ProjectService.getProjectYears())


### PR DESCRIPTION
The ExportPathMap was deprecated.  The easiest way to obtain the same functionality is to make it a rewrite.

I have also added the ability to test what the prod environment is supposed to be like.

So instead of running
```
npm start
```

run
```
npm run-script prod
```
to see what prod environment errors we get.